### PR TITLE
Bug fix for printing the expectation for the sample 2 in the final_pr…

### DIFF
--- a/machine_translation.ipynb
+++ b/machine_translation.ipynb
@@ -594,7 +594,7 @@
     "    print('Il a vu un vieux camion jaune')\n",
     "    print('Sample 2:')\n",
     "    print(' '.join([y_id_to_word[np.argmax(x)] for x in predictions[1]]))\n",
-    "    print(' '.join([y_id_to_word[np.argmax(x)] for x in y[0]]))\n",
+    "    print(' '.join([y_id_to_word[x[0]] for x in y[0]]))\n",
     "\n",
     "\n",
     "final_predictions(preproc_english_sentences, preproc_french_sentences, english_tokenizer, french_tokenizer)"


### PR DESCRIPTION
I found a bug in the final_predictions function.
Currently it shows all <PAD>s for the expectation for the Sample 2 as np.argmax(x) always returns zero.
Therefore, I changed it simply to refer the first index of the label given.